### PR TITLE
[JENKINS-50483] - Make the plugin compatible with Jenkins 2.102+ (JEP-200)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, "2.107.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.29</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>3.6</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -12,8 +12,13 @@
   <packaging>hpi</packaging>
   
   <name>aws-device-farm</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/AWS+Device+Farm+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/AWS+Device+Farm+Plugin</url>
   <description>AWS Device Farm Jenkins Plugin</description>
+
+  <properties>
+    <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
+  </properties>
   
   <dependencies>
     <dependency>
@@ -22,16 +27,18 @@
       <version>1.20</version>
     </dependency>
 
+    <!-- TODO: use AWS SDK Plugin instead: https://plugins.jenkins.io/aws-java-sdk -->
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
       <version>1.11.126</version>
     </dependency>
-    
+
+    <!-- TODO: Use Apache HttpComponents Client 4.x API instead: https://plugins.jenkins.io/apache-httpcomponents-client-4-api -->
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4</version>
+        <version>4.4.4</version>
     </dependency>
   </dependencies>
 
@@ -65,12 +72,10 @@
     </developer>
   </developers>
 
-  
-  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
     <repository>
       <id>central</id>
@@ -86,17 +91,9 @@
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
-  <properties>
-    <!--
-      explicitly specifying the latest version here because one we get from the parent POM
-      tends to lag behind a bit
-    -->
-    <maven-hpi-plugin.version>1.96</maven-hpi-plugin.version>
-  </properties>
 
   <build>
     <plugins>
@@ -106,18 +103,6 @@
         <configuration>
           <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.1</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.scm</groupId>
-            <artifactId>maven-scm-provider-gitexe</artifactId>
-            <version>1.9.2</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -69,6 +69,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -242,7 +243,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
                                  String devicePoolName,
                                  String appArtifact,
                                  String runName,
-                                 String testToRun,
+                                 @Nonnull String testToRun,
                                  Boolean storeResults,
                                  Boolean isRunUnmetered,
                                  String eventCount,
@@ -360,7 +361,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
      * @param testToRun The String representation of the test type.
      * @return The String should bu input as the parameter of the devicefarm API.
      */
-    public String transformTestToRunForWebApp(String testToRun) {
+    public String transformTestToRunForWebApp(@Nonnull String testToRun) {
         if (ifWebApp) {
             if (testToRun.equalsIgnoreCase("APPIUM_PYTHON")) return"APPIUM_WEB_PYTHON";
             else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_JUNIT")) return"APPIUM_WEB_JAVA_JUNIT";

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -147,9 +147,6 @@ public class AWSDeviceFarmRecorder extends Recorder {
     public String xctestUiArtifact;
     public String xctestUiFilter;
 
-    // Fields not populated by the JSON binder.
-    public PrintStream log;
-
     // ignore device farm run errors
     public Boolean ignoreRunError;
 
@@ -404,7 +401,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
         EnvVars env = build.getEnvironment(listener);
         Map<String, String> parameters = build.getBuildVariables();
 
-        log = listener.getLogger();
+        final PrintStream log = listener.getLogger();
 
         // Artifacts location for this build on master.
         FilePath artifactsDir = new FilePath(build.getArtifactsDir());
@@ -413,9 +410,9 @@ public class AWSDeviceFarmRecorder extends Recorder {
         FilePath workspace = build.getWorkspace();
 
         // Validate user selection & input values.
-        boolean isValid = validateConfiguration() && validateTestConfiguration();
+        boolean isValid = validateConfiguration(log) && validateTestConfiguration(log);
         if (!isValid) {
-            writeToLog("Invalid configuration.");
+            writeToLog(log, "Invalid configuration.");
             return false;
         }
 
@@ -430,7 +427,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             // Accept 'ADF_PROJECT' build parameter as an overload from job configuration.
             String projectNameParameter = parameters.get("AWSDEVICEFARM_PROJECT");
             if (projectNameParameter != null && !projectNameParameter.isEmpty()) {
-                writeToLog(String.format("Using overloaded project '%s' from build parameters", projectNameParameter));
+                writeToLog(log, String.format("Using overloaded project '%s' from build parameters", projectNameParameter));
                 projectName = projectNameParameter;
             }
 
@@ -445,28 +442,28 @@ public class AWSDeviceFarmRecorder extends Recorder {
             }
 
             // Get AWS Device Farm project from user provided name.
-            writeToLog(String.format("Using Project '%s'", projectName));
+            writeToLog(log, String.format("Using Project '%s'", projectName));
             Project project = adf.getProject(projectName);
 
             // Accept 'ADF_DEVICE_POOL' build parameter as an overload from job configuration.
             String devicePoolParameter = parameters.get("AWSDEVICEFARM_DEVICE_POOL");
             if (devicePoolParameter != null) {
-                writeToLog(String.format("Using overloaded device pool '%s' from build parameters", devicePoolParameter));
+                writeToLog(log, String.format("Using overloaded device pool '%s' from build parameters", devicePoolParameter));
                 devicePoolName = devicePoolParameter;
             }
 
             // Get AWS Device Farm device pool from user provided name.
-            writeToLog(String.format("Using DevicePool '%s'", devicePoolName));
+            writeToLog(log, String.format("Using DevicePool '%s'", devicePoolName));
             DevicePool devicePool = adf.getDevicePool(project, devicePoolName);
 
             // Upload app.
             String appArn = null;
             if (ifWebApp != null && ifWebApp){
-                writeToLog("Tesing a Web App.");
+                writeToLog(log, "Tesing a Web App.");
 
             }
             else {
-                writeToLog(String.format("Using App '%s'", env.expand(appArtifact)));
+                writeToLog(log, String.format("Using App '%s'", env.expand(appArtifact)));
                 Upload appUpload = adf.uploadApp(project, appArtifact);
                 appArn = appUpload.getArn();
             }
@@ -479,7 +476,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             }
 
             // Upload test content.
-            writeToLog("Getting test to schedule.");
+            writeToLog(log, "Getting test to schedule.");
             ScheduleRunTest testToSchedule = getScheduleRunTest(env, adf, project);
 
             if (ifVideoRecording != null && !ifVideoRecording) {
@@ -491,25 +488,25 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
 
             // State the Appium Version.
-            if (testToRun.equalsIgnoreCase("APPIUM_JAVA_JUNIT")) writeToLog(String.format("Using appium version: %s", appiumVersionJunit));
-            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_JAVA_JUNIT")) writeToLog(String.format("Using appium version: %s", appiumVersionJunit));
-            else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_TESTNG")) writeToLog(String.format("Using appium version: %s", appiumVersionTestng));
-            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_JAVA_TESTNG")) writeToLog(String.format("Using appium version: %s", appiumVersionTestng));
-            else if (testToRun.equalsIgnoreCase("APPIUM_PYTHON")) writeToLog(String.format("Using appium version: %s", appiumVersionPython));
-            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_PYTHON")) writeToLog(String.format("Using appium version: %s", appiumVersionPython));
+            if (testToRun.equalsIgnoreCase("APPIUM_JAVA_JUNIT")) writeToLog(log, String.format("Using appium version: %s", appiumVersionJunit));
+            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_JAVA_JUNIT")) writeToLog(log, String.format("Using appium version: %s", appiumVersionJunit));
+            else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_TESTNG")) writeToLog(log, String.format("Using appium version: %s", appiumVersionTestng));
+            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_JAVA_TESTNG")) writeToLog(log, String.format("Using appium version: %s", appiumVersionTestng));
+            else if (testToRun.equalsIgnoreCase("APPIUM_PYTHON")) writeToLog(log, String.format("Using appium version: %s", appiumVersionPython));
+            else if (testToRun.equalsIgnoreCase("APPIUM_WEB_PYTHON")) writeToLog(log, String.format("Using appium version: %s", appiumVersionPython));
 
 
             // Upload the extra data.
             String extraDataArn = null;
             if (extraData != null && extraData) {
-                writeToLog(String.format("Using Extra Data '%s'", env.expand(extraDataArtifact)));
+                writeToLog(log, String.format("Using Extra Data '%s'", env.expand(extraDataArtifact)));
                 Upload extraDataUpload = adf.uploadExtraData(project, extraDataArtifact);
                 extraDataArn = extraDataUpload.getArn();
             }
 
             // Schedule test run.
             TestType testType = TestType.fromValue(testToSchedule.getType());
-            writeToLog(String.format("Scheduling '%s' run '%s'", testType, deviceFarmRunName));
+            writeToLog(log, String.format("Scheduling '%s' run '%s'", testType, deviceFarmRunName));
 
             ScheduleRunConfiguration configuration = getScheduleRunConfiguration(isRunUnmetered, deviceLocation, radioDetails);
             configuration.setExtraDataPackageArn(extraDataArn);
@@ -518,9 +515,9 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             String runArn = run.getRun().getArn();
             try {
-                writeToLog(String.format("View the %s run in the AWS Device Farm Console: %s", testType, AWSDeviceFarmUtils.getRunUrlFromArn(runArn)));
+                writeToLog(log, String.format("View the %s run in the AWS Device Farm Console: %s", testType, AWSDeviceFarmUtils.getRunUrlFromArn(runArn)));
             } catch (ArrayIndexOutOfBoundsException e) {
-                writeToLog(String.format("Could not parse project ID and run ID from run ARN: %s", runArn));
+                writeToLog(log, String.format("Could not parse project ID and run ID from run ARN: %s", runArn));
             }
 
             // Attach AWS Device Farm action to poll periodically and update results UI.
@@ -528,9 +525,9 @@ public class AWSDeviceFarmRecorder extends Recorder {
             build.addAction(action);
 
             // Wait for test result to complete will updating status periodically.
-            writeToLog("Waiting for test run to complete.");
+            writeToLog(log, "Waiting for test run to complete.");
             action.waitForRunCompletion(adf, run);
-            writeToLog("Test run is complete.");
+            writeToLog(log, "Test run is complete.");
 
 
             // Download results archive and store it.
@@ -538,13 +535,13 @@ public class AWSDeviceFarmRecorder extends Recorder {
                 // Create results storage directory which will contain the unzip logs/screenshots pulled from AWS Device Farm.
                 FilePath resultsDir = new FilePath(artifactsDir, "AWS Device Farm Results");
                 resultsDir.mkdirs();
-                writeToLog(String.format("Storing AWS Device Farm results in directory %s", resultsDir));
+                writeToLog(log, String.format("Storing AWS Device Farm results in directory %s", resultsDir));
 
                 Map<String, FilePath> jobs = getJobs(adf, run, resultsDir);
                 Map<String, FilePath> suites = getSuites(adf, run, jobs);
                 Map<String, FilePath> tests = getTests(adf, run, suites);
 
-                writeToLog("Downloading AWS Device Farm results archive...");
+                writeToLog(log, "Downloading AWS Device Farm results archive...");
                 // Iterating over all values in the Enum.
                 for (ArtifactCategory category : new ArrayList<ArtifactCategory>(Arrays.asList(ArtifactCategory.values()))) {
                     ListArtifactsResult result = adf.listArtifacts(run.getRun().getArn(), category);
@@ -558,13 +555,13 @@ public class AWSDeviceFarmRecorder extends Recorder {
                         artifactFilePath.write().write(IOUtils.toByteArray(url.openStream()));
                     }
                 }
-                writeToLog(String.format("Results archive saved in %s", artifactsDir.getName()));
+                writeToLog(log, String.format("Results archive saved in %s", artifactsDir.getName()));
             }
 
             // Set Jenkins build result based on AWS Device Farm test result.
             build.setResult(action.getBuildResult(ignoreRunError));
         } catch (AWSDeviceFarmException e) {
-            writeToLog(e.getMessage());
+            writeToLog(log, e.getMessage());
             return false;
         }
 
@@ -930,37 +927,38 @@ public class AWSDeviceFarmRecorder extends Recorder {
     /**
      * Validate top level configuration values.
      *
+     * @param log Destination Task Log
      * @return Whether or not the configuration is valid.
      */
-    private boolean validateConfiguration() {
+    private boolean validateConfiguration(@Nonnull PrintStream log) {
         String roleArn = getRoleArn();
         String akid = getAkid();
         String skid = getSkid();
 
         // [Required]: Auth Credentials
         if ((roleArn == null || roleArn.isEmpty()) && (akid == null || akid.isEmpty() || skid == null || skid.isEmpty())) {
-            writeToLog("Either IAM Role ARN or AKID/SKID must be set.");
+            writeToLog(log, "Either IAM Role ARN or AKID/SKID must be set.");
             return false;
         }
 
         // [Required]: Project
         if (projectName == null || projectName.isEmpty()) {
-            writeToLog("Project must be set.");
+            writeToLog(log, "Project must be set.");
             return false;
         }
         // [Required]: DevicePool
         if (devicePoolName == null || devicePoolName.isEmpty()) {
-            writeToLog("DevicePool must be set.");
+            writeToLog(log, "DevicePool must be set.");
             return false;
         }
         // [Required]: App Artifact
         if (!ifWebApp && (appArtifact == null || appArtifact.isEmpty())) {
-            writeToLog("Application Artifact must be set.");
+            writeToLog(log, "Application Artifact must be set.");
             return false;
         }
         // [Required]: At least one test.
         if (testToRun == null || stringToTestType(testToRun) == null) {
-            writeToLog("A test type must be set.");
+            writeToLog(log, "A test type must be set.");
             return false;
         }
         return true;
@@ -969,9 +967,10 @@ public class AWSDeviceFarmRecorder extends Recorder {
     /**
      * Validate user selected test type and additional configuration values.
      *
+     * @param log Destination Task Log
      * @return Whether or not the test configuration is valid.
      */
-    private boolean validateTestConfiguration() {
+    private boolean validateTestConfiguration(@Nonnull PrintStream log) {
         TestType testType = stringToTestType(testToRun);
 
         switch (testType) {
@@ -979,14 +978,14 @@ public class AWSDeviceFarmRecorder extends Recorder {
                 // [Optional]: EventCount (int)
                 if (eventCount != null && !eventCount.isEmpty()) {
                     if (!eventCount.matches("^\\d+$")) {
-                        writeToLog("EventCount must be a number.");
+                        writeToLog(log,"EventCount must be a number.");
                         return false;
                     }
                 }
                 // [Optional]: Seed (int)
                 if (seed != null && !seed.isEmpty()) {
                     if (!seed.matches("^\\d+$")) {
-                        writeToLog("Seed must be a number.");
+                        writeToLog(log, "Seed must be a number.");
                         return false;
                     }
                 }
@@ -1000,7 +999,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_JAVA_JUNIT: {
                 if (appiumJavaJUnitTest == null || appiumJavaJUnitTest.isEmpty()) {
-                    writeToLog("Appium Java Junit test must be set.");
+                    writeToLog(log, "Appium Java Junit test must be set.");
                     return false;
                 }
 
@@ -1009,7 +1008,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_JAVA_TESTNG: {
                 if (appiumJavaTestNGTest == null || appiumJavaTestNGTest.isEmpty()) {
-                    writeToLog("Appium Java TestNG test must be set.");
+                    writeToLog(log, "Appium Java TestNG test must be set.");
                     return false;
                 }
 
@@ -1018,7 +1017,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_PYTHON: {
                 if (appiumPythonTest == null || appiumPythonTest.isEmpty()) {
-                    writeToLog("Appium Python test must be set.");
+                    writeToLog(log, "Appium Python test must be set.");
                     return false;
                 }
 
@@ -1027,7 +1026,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_WEB_JAVA_JUNIT: {
                 if (appiumJavaJUnitTest == null || appiumJavaJUnitTest.isEmpty()) {
-                    writeToLog("Appium Java Junit test for the web application must be set.");
+                    writeToLog(log, "Appium Java Junit test for the web application must be set.");
                     return false;
                 }
 
@@ -1036,7 +1035,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_WEB_JAVA_TESTNG: {
                 if (appiumJavaTestNGTest == null || appiumJavaTestNGTest.isEmpty()) {
-                    writeToLog("Appium Java TestNG test for the web application must be set.");
+                    writeToLog(log, "Appium Java TestNG test for the web application must be set.");
                     return false;
                 }
 
@@ -1045,7 +1044,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case APPIUM_WEB_PYTHON: {
                 if (appiumPythonTest == null || appiumPythonTest.isEmpty()) {
-                    writeToLog("Appium Python test for the web application must be set.");
+                    writeToLog(log, "Appium Python test for the web application must be set.");
                     return false;
                 }
 
@@ -1055,12 +1054,12 @@ public class AWSDeviceFarmRecorder extends Recorder {
             case CALABASH: {
                 // [Required]: Features Path
                 if (calabashFeatures == null || calabashFeatures.isEmpty()) {
-                    writeToLog("Calabash Features must be set.");
+                    writeToLog(log, "Calabash Features must be set.");
                     return false;
                 }
                 // [Required]: Features.zip
                 if (!calabashFeatures.endsWith(".zip")) {
-                    writeToLog("Calabash content must be of type .zip");
+                    writeToLog(log, "Calabash content must be of type .zip");
                     return false;
                 }
 
@@ -1070,7 +1069,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             case INSTRUMENTATION: {
                 // [Required]: Tests Artifact
                 if (junitArtifact == null || junitArtifact.isEmpty()) {
-                    writeToLog("JUnit tests Artifact must be set.");
+                    writeToLog(log, "JUnit tests Artifact must be set.");
                     return false;
                 }
 
@@ -1079,7 +1078,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case UIAUTOMATOR: {
                 if (uiautomatorArtifact == null || uiautomatorArtifact.isEmpty()) {
-                    writeToLog("UI Automator tests artifact must be set.");
+                    writeToLog(log, "UI Automator tests artifact must be set.");
                     return false;
                 }
 
@@ -1088,7 +1087,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case UIAUTOMATION: {
                 if (uiautomationArtifact == null || uiautomationArtifact.isEmpty()) {
-                    writeToLog("UI Automation tests artifact must be set.");
+                    writeToLog(log, "UI Automation tests artifact must be set.");
                     return false;
                 }
 
@@ -1097,7 +1096,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case XCTEST: {
                 if (xctestArtifact == null || xctestArtifact.isEmpty()) {
-                    writeToLog("XC tests artifact must be set.");
+                    writeToLog(log, "XC tests artifact must be set.");
                     return false;
                 }
 
@@ -1106,7 +1105,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
             case XCTEST_UI: {
                 if (xctestUiArtifact == null || xctestUiArtifact.isEmpty()) {
-                    writeToLog("XCTest UI tests artifact must be set.");
+                    writeToLog(log, "XCTest UI tests artifact must be set.");
                     return false;
                 }
 
@@ -1114,7 +1113,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             }
 
             default: {
-                writeToLog("Must select a test type to run.");
+                writeToLog(log, "Must select a test type to run.");
                 return false;
             }
         }
@@ -1125,9 +1124,10 @@ public class AWSDeviceFarmRecorder extends Recorder {
     /**
      * Helper method for writing entries to the Jenkins log.
      *
+     * @param log Destination log
      * @param msg The message to be written to the Jenkins log.
      */
-    private void writeToLog(String msg) {
+    private void writeToLog(PrintStream log, String msg) {
         log.println(String.format("[AWSDeviceFarm] %s", msg));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -19,9 +19,11 @@ import com.amazonaws.services.devicefarm.model.Run;
 import com.amazonaws.services.devicefarm.model.ScheduleRunResult;
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
+import hudson.model.TaskListener;
 import hudson.tasks.test.AbstractTestResultAction;
 import org.kohsuke.stapler.StaplerProxy;
 
+import javax.annotation.CheckForNull;
 import java.io.PrintStream;
 
 /**
@@ -35,14 +37,19 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
 
     private static final int DefaultUpdateInterval = 30 * 1000;
 
-    private PrintStream log;
     private AWSDeviceFarmTestResult result;
 
-    public AWSDeviceFarmTestResultAction(AbstractBuild<?, ?> owner, AWSDeviceFarmTestResult result, PrintStream log) {
-
+    public AWSDeviceFarmTestResultAction(AbstractBuild<?, ?> owner, AWSDeviceFarmTestResult result) {
         super(owner);
-        this.log = log;
         this.result = result;
+    }
+
+    /**
+     * @deprecated log is no longer passed, use {@link #AWSDeviceFarmTestResultAction(AbstractBuild, AWSDeviceFarmTestResult)}
+     */
+    @Deprecated
+    public AWSDeviceFarmTestResultAction(AbstractBuild<?, ?> owner, AWSDeviceFarmTestResult result, @CheckForNull PrintStream log) {
+        this(owner, result);
     }
 
     /**
@@ -54,6 +61,10 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
         return getResult().getBuildResult(ignoreRunError);
     }
 
+    public void waitForRunCompletion(AWSDeviceFarm adf, ScheduleRunResult runResult) throws InterruptedException {
+        waitForRunCompletion(adf, runResult, TaskListener.NULL);
+    }
+
     /**
      * Blocking function which periodically polls the given AWS Device Farm run until its completed. During this waiting period,
      * we will grab the latest results reported by Device Farm and updated our internal result "snapshot" which will be used
@@ -61,19 +72,20 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
      *
      * @param runResult
      */
-    public void waitForRunCompletion(AWSDeviceFarm adf, ScheduleRunResult runResult) throws InterruptedException {
+    public void waitForRunCompletion(AWSDeviceFarm adf, ScheduleRunResult runResult, TaskListener listener) throws InterruptedException {
+        PrintStream log = listener.getLogger();
         while (true) {
             GetRunResult latestRunResult = adf.describeRun(runResult.getRun().getArn());
             Run run = latestRunResult.getRun();
             result = new AWSDeviceFarmTestResult(owner, run);
-            writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
+            writeToLog(log, String.format("Run %s status %s", run.getName(), run.getStatus()));
             if (result.isCompleted()) {
                 break;
             }
             try {
                 Thread.sleep(DefaultUpdateInterval);
             } catch (InterruptedException ex) {
-                writeToLog(String.format("Thread interrupted while waiting for the Run to complete"));
+                writeToLog(log, String.format("Thread interrupted while waiting for the Run to complete"));
                 throw ex;
             }
         }
@@ -163,7 +175,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
 
     //// Helper Methods
 
-    private void writeToLog(String message) {
+    private void writeToLog(PrintStream log, String message) {
         if (log != null) {
             log.println(String.format("[AWSDeviceFarm] %s", message));
         }

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.awsdevicefarm;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.util.VersionNumber;
+import jenkins.model.Jenkins;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+@For(AWSDeviceFarmRecorder.class)
+public class AWSDeviceFarmRecorderTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-50483")
+    public void dataSerializationSmokeTest() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        AWSDeviceFarmRecorder rec = new AWSDeviceFarmRecorder(
+                "TestProjectName", "TestDevicePool",
+                null, null, "APPIUM_JAVA_JUNIT", false, false, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                null, null, null, null, false, false,
+                null, null, null, null, null, null,
+                false, false, false, 10, false, false,
+                false
+        );
+        p.getPublishersList().add(rec);
+
+        // Try to build it. It is not supposed to work, but we will filter out the JEP-200 exception
+        final QueueTaskFuture<FreeStyleBuild> future = p.scheduleBuild2(0);
+        final FreeStyleBuild build = future.get();
+        j.assertBuildStatus(Result.FAILURE, build);
+        // Currently it fails with Either IAM Role ARN or AKID/SKID must be set and does not report the serialization issue after that
+
+        // No matter what, we should be able to save the project even after the failure
+        p.save();
+        build.save();
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -1,11 +1,23 @@
+//
+// Copyright 2018 CloudBees, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
 package org.jenkinsci.plugins.awsdevicefarm;
 
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
-import hudson.util.VersionNumber;
-import jenkins.model.Jenkins;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.For;

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultActionTest.java
@@ -1,0 +1,77 @@
+//
+// Copyright 2018 CloudBees, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+package org.jenkinsci.plugins.awsdevicefarm;
+
+import com.amazonaws.services.devicefarm.model.Counters;
+import com.amazonaws.services.devicefarm.model.DeviceMinutes;
+import com.amazonaws.services.devicefarm.model.ExecutionResult;
+import com.amazonaws.services.devicefarm.model.NetworkProfile;
+import com.amazonaws.services.devicefarm.model.Run;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.util.LogTaskListener;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.For;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@For(AWSDeviceFarmTestResultAction.class)
+public class AWSDeviceFarmTestResultActionTest {
+
+    private static final Logger LOGGER = Logger.getLogger(AWSDeviceFarmTestResultActionTest.class.getName());
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    @Issue("JENKINS-50483")
+    public void roundtrip() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+        FreeStyleBuild build = j.buildAndAssertSuccess(p);
+
+        // Here we set a run with all fields which are potentially not allowed in JEP-200
+        // TODO: to make the test more robust, it is possible to iterate through fields and use Setters with default constructors. Looks like it's fine for StructuredPojo
+        Run awsRun = new Run();
+        awsRun.setArn("a:b:c:d:e:f:foo/bar");
+        awsRun.setResult(ExecutionResult.SKIPPED);
+        awsRun.setNetworkProfile(new NetworkProfile());
+        awsRun.setDeviceMinutes(new DeviceMinutes());
+        Counters counters = new Counters();
+        counters.setPassed(0);
+        counters.setFailed(0);
+        counters.setSkipped(1);
+        counters.setErrored(0);
+        counters.setStopped(0);
+        counters.setWarned(0);
+        counters.setTotal(1);
+        awsRun.setCounters(counters);
+
+        // We intentionally use the deprecated constructor to check whether logger is retained
+        AWSDeviceFarmTestResult res = new AWSDeviceFarmTestResult(build, awsRun);
+        AWSDeviceFarmTestResultAction a = new AWSDeviceFarmTestResultAction(build, res, new LogTaskListener(LOGGER, Level.SEVERE).getLogger());
+        build.addAction(a);
+
+        // Check that the action is still there after reload
+        build.save();
+        build.reload();
+        Assert.assertNotNull("AWSDeviceFarmTestResultAction should be retained after the restart", build.getAction(AWSDeviceFarmTestResultAction.class));
+    }
+
+}


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50483
More info about JEP-200: https://jenkins.io/blog/2018/03/15/jep-200-lts/

- [x] - Facelift the plugin so that in can be tested with [Plugin Compat Tester](https://github.com/jenkinsci/plugin-compat-tester)
- [x] - Add a smoke test to reproduce the issue. There is no other tests in the plugin
- [x] - Fix the issue, stop persisting `PrintStream` within the AWSDviceFarmReporter. It is a bug in the plugin, build objects should not be persisted on the project level
- [x] - Add Jenkinsfile fo ci.jenkins.io

@reviewbybees @jglick @nikhil-dabhade 
