### PR TITLE
Add support for pulling data from devices

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -36,6 +36,7 @@ import com.amazonaws.services.devicefarm.model.Radios;
 import com.amazonaws.services.devicefarm.model.ScheduleRunConfiguration;
 import com.amazonaws.services.devicefarm.model.ScheduleRunResult;
 import com.amazonaws.services.devicefarm.model.ScheduleRunTest;
+import com.amazonaws.services.devicefarm.model.CustomerArtifactPaths;
 import com.amazonaws.services.devicefarm.model.Suite;
 import com.amazonaws.services.devicefarm.model.Test;
 import com.amazonaws.services.devicefarm.model.TestType;
@@ -80,6 +81,7 @@ import org.jenkinsci.plugins.awsdevicefarm.test.XCTestTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.XCTestUITest;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -188,6 +190,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     // Device States Specification
     public Boolean extraData;
     public String extraDataArtifact;
+    public String androidPathField;
+    public String iosPathField;
 
     // VPCE Configuration
     public String vpceServiceName;
@@ -202,6 +206,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     public Boolean ifGPS;
     public Boolean ifNfc;
     public Boolean ifBluetooth;
+    public Boolean ifPullDataPath;
 
     public Integer jobTimeoutMinutes;
 
@@ -325,7 +330,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                                  Boolean ignoreRunError,
                                  Boolean ifVpce,
                                  Boolean ifSkipAppResigning,
-                                 String vpceServiceName ) {
+                                 String vpceServiceName,
+                                 Boolean ifPullDataPath,
+                                 String androidPathField,
+                                 String iosPathField) {
         this.projectName = projectName;
         this.devicePoolName = devicePoolName;
         this.testSpecName = testSpecName;
@@ -378,6 +386,9 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         this.ifAppPerformanceMonitoring = ifAppPerformanceMonitoring;
         this.ifWebApp = ifWebApp;
         this.testToRun = transformTestToRunForWebApp(testToRun);
+        this.ifPullDataPath = ifPullDataPath;
+        this.androidPathField = androidPathField;
+        this.iosPathField = iosPathField;
 
         // This is a hack because I have to get the service icon locally, but it's copy-righted. So I pull it when I need it.
         Path pluginIconPath = Paths.get(System.getenv("HOME"), "plugins", "aws-device-farm", "service-icon.svg").toAbsolutePath();
@@ -392,6 +403,21 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 e.printStackTrace();
             }
         }
+    }
+
+    @DataBoundSetter
+    public void setIfPullDataPath(boolean ifPullDataPath) {
+        this.ifPullDataPath = ifPullDataPath;
+    }
+
+    @DataBoundSetter
+    public void setIosPathField(String iosPathField) {
+        this.iosPathField = iosPathField;
+    }
+
+    @DataBoundSetter
+    public void setAndroidPathField(String androidPathField) {
+        this.androidPathField = androidPathField;
     }
 
     /**
@@ -737,6 +763,17 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         // set a bunch of other default values as Device Farm expect these
         configuration.setAuxiliaryApps(new ArrayList<String>());
         configuration.setLocale("en_US");
+
+        if (ifPullDataPath != null && ifPullDataPath) {
+            CustomerArtifactPaths paths = new CustomerArtifactPaths();
+            if (androidPathField != null) {
+                paths.setAndroidPaths(Arrays.asList(androidPathField.split("\\s*,\\s*")));
+            }
+            if (iosPathField != null) {
+                paths.setIosPaths(Arrays.asList(iosPathField.split("\\s*,\\s*")));
+            }
+            configuration.setCustomerArtifactPaths(paths);
+        }
 
         Location location = getScheduleRunConfigurationLocation(deviceLocation);
         configuration.setLocation(location);

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -256,5 +256,13 @@
       <f:checkbox name="ifSkipAppResigning" title="Enable Skip App Resigning (for private devices only)" default="false" checked="${instance.ifSkipAppResigning}" inline="true"/>
     </f:entry>
 
+    <f:optionalBlock name="ifPullDataPath" title="Pull data from device." checked="${instance.ifPullDataPath}" inline="true">
+      <f:entry title="Android Path" field="androidPathField" description="[Optional] Pull specified directory from device to the workspace." >
+        <f:textbox />
+      </f:entry>
+      <f:entry title="iOS Path" field="iosPathField" description="[Optional] Pull specified directory from device to the workspace." >
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -43,7 +43,7 @@ public class AWSDeviceFarmRecorderTest {
                 null, null, null, null, false, false,
                 null, null, null, null, null, null,
                 false, false, false, 10, false, false,
-                false, false, false, null
+                false, false, false, null, true, "", "A, B"
         );
         p.getPublishersList().add(rec);
 


### PR DESCRIPTION
Support for CustomerArtifactPaths introduced in newer AWS SDK to pull data from the device after tests have finished to run.

Adds an optional configuration section to specify the paths to the data for iOS and Android.