### PR TITLE
Fix for video capture attribute and test spec file

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -672,7 +672,8 @@ public class AWSDeviceFarm {
                                          String devicePoolArn,
                                          ScheduleRunTest test,
                                          Integer jobTimeoutMinutes,
-                                         ScheduleRunConfiguration configuration) {
+                                         ScheduleRunConfiguration configuration,
+                                         Boolean videoCapture) {
         ScheduleRunRequest request = new ScheduleRunRequest()
                 .withProjectArn(projectArn)
                 .withName(name)
@@ -682,8 +683,9 @@ public class AWSDeviceFarm {
         ExecutionConfiguration exeConfiguration = new ExecutionConfiguration();
         if (!jobTimeoutMinutes.equals(DEFAULT_JOB_TIMEOUT_MINUTE)) {
             exeConfiguration.setJobTimeoutMinutes(jobTimeoutMinutes);
-            request.withExecutionConfiguration(exeConfiguration);
         }
+        exeConfiguration.setVideoCapture(videoCapture);
+        request.withExecutionConfiguration(exeConfiguration);
 
         if (configuration != null) {
             request.withConfiguration(configuration);

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -49,6 +49,7 @@ import com.amazonaws.services.devicefarm.model.ScheduleRunRequest;
 import com.amazonaws.services.devicefarm.model.ScheduleRunResult;
 import com.amazonaws.services.devicefarm.model.ScheduleRunTest;
 import com.amazonaws.services.devicefarm.model.Upload;
+import com.amazonaws.services.devicefarm.model.UploadStatus;
 import com.amazonaws.services.devicefarm.model.VPCEConfiguration;
 import com.amazonaws.services.devicefarm.model.ListVPCEConfigurationsResult;
 import com.amazonaws.services.devicefarm.model.ListVPCEConfigurationsRequest;
@@ -277,10 +278,11 @@ public class AWSDeviceFarm {
         List<Upload> allUploads = getUploads(project);
         List<Upload> testSpecUploads = new ArrayList<Upload>();
         for (Upload upload : allUploads) {
-            if (upload.getType().contains("TEST_SPEC")) {
-                testSpecUploads.add(upload);
+			if (upload.getType().contains("TEST_SPEC")
+					&& UploadStatus.SUCCEEDED.toString().equals(upload.getStatus())) {
+				testSpecUploads.add(upload);
 
-            }
+			}
         }
         return testSpecUploads;
     }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -556,8 +556,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             writeToLog(log, "Getting test to schedule.");
             ScheduleRunTest testToSchedule = getScheduleRunTest(env, adf, project);
 
+            // by default videoCapture is always enabled
+            Boolean videoCapture = true;
             if (ifVideoRecording != null && !ifVideoRecording) {
-                testToSchedule.addParametersEntry("video_recording", "false");
+                videoCapture = false;
             }
             if (ifAppPerformanceMonitoring != null && !ifAppPerformanceMonitoring) {
                 testToSchedule.addParametersEntry("app_performance_monitoring", "false");
@@ -598,7 +600,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 configuration.setVpceConfigurationArns(vpceConfigurationArns);
             }
 
-            ScheduleRunResult run = adf.scheduleRun(project.getArn(), deviceFarmRunName, appArn, devicePool.getArn(), testToSchedule, jobTimeoutMinutes, configuration);
+            ScheduleRunResult run = adf.scheduleRun(project.getArn(), deviceFarmRunName, appArn, devicePool.getArn(), testToSchedule, jobTimeoutMinutes, configuration, videoCapture);
 
             String runArn = run.getRun().getArn();
             try {


### PR DESCRIPTION
1. Use the new video capture attribute in schedule run API.
2. Upload test spec in SUCCEEDED state only.