### PR TITLE
Support for Ruby and Node in custom environment, bug fixes and env variable in filters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.466</version>
+      <version>1.11.478</version>
     </dependency>
 
     <!-- TODO: Use Apache HttpComponents Client 4.x API instead: https://plugins.jenkins.io/apache-httpcomponents-client-4-api -->

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -95,6 +95,11 @@ public class AWSDeviceFarm {
     private EnvVars env;
 
     private static final Integer DEFAULT_JOB_TIMEOUT_MINUTE = 60;
+    private static final String APPIUM_RUBY_TEST_SPEC = "APPIUM_RUBY_TEST_SPEC";
+    private static final String APPIUM_NODE_TEST_SPEC = "APPIUM_NODE_TEST_SPEC";
+    private static final String APPIUM_WEB_RUBY_TEST_SPEC = "APPIUM_WEB_RUBY_TEST_SPEC";
+    private static final String APPIUM_WEB_NODE_TEST_SPEC = "APPIUM_WEB_NODE_TEST_SPEC";
+    private static final String CURATED = "CURATED";
 
     //// Constructors
 
@@ -300,12 +305,14 @@ public class AWSDeviceFarm {
      * @throws AWSDeviceFarmException
      */
     public Boolean isRestrictedDefaultSpec(Upload testSpec) {
-        if ((testSpec.getType().equals("APPIUM_RUBY_TEST_SPEC") ||
-            testSpec.getType().equals("APPIUM_NODE_TEST_SPEC") ||
-            testSpec.getType().equals("APPIUM_WEB_RUBY_TEST_SPEC") ||
-            testSpec.getType().equals("APPIUM_WEB_NODE_TEST_SPEC")) &&
-            (testSpec.getCategory().equals("CURATED"))) {
-            return true;
+        if (testSpec != null) {
+            if ((APPIUM_RUBY_TEST_SPEC.equals(testSpec.getType()) ||
+                APPIUM_NODE_TEST_SPEC.equals(testSpec.getType()) ||
+                APPIUM_WEB_RUBY_TEST_SPEC.equals(testSpec.getType()) ||
+                APPIUM_WEB_NODE_TEST_SPEC.equals(testSpec.getType())) &&
+                (CURATED.equals(testSpec.getCategory()))) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -272,7 +272,7 @@ public class AWSDeviceFarm {
     }
 
     /**
-     * Get Device Farm TestSpecs  for a given Device Farm project.
+     * Get Device Farm TestSpecs for a given Device Farm project.
      *
      * @param project Device Farm Project.
      * @return A List of the Device Farm TestSpecs.
@@ -283,12 +283,31 @@ public class AWSDeviceFarm {
         List<Upload> testSpecUploads = new ArrayList<Upload>();
         for (Upload upload : allUploads) {
 			if (upload.getType().contains("TEST_SPEC")
-					&& UploadStatus.SUCCEEDED.toString().equals(upload.getStatus())) {
+					&& UploadStatus.SUCCEEDED.toString().equals(upload.getStatus()) && !isRestrictedDefaultSpec(upload)) {
 				testSpecUploads.add(upload);
 
 			}
         }
         return testSpecUploads;
+    }
+
+    /**
+     * Helper function to detect a default testspec file for frameworks that cannot use it.
+     *
+     * @param upload Testspec
+     *
+     * @return true if it is a default spec file.
+     * @throws AWSDeviceFarmException
+     */
+    public Boolean isRestrictedDefaultSpec(Upload testSpec) {
+        if ((testSpec.getType().equals("APPIUM_RUBY_TEST_SPEC") ||
+            testSpec.getType().equals("APPIUM_NODE_TEST_SPEC") ||
+            testSpec.getType().equals("APPIUM_WEB_RUBY_TEST_SPEC") ||
+            testSpec.getType().equals("APPIUM_WEB_NODE_TEST_SPEC")) &&
+            (testSpec.getCategory().equals("CURATED"))) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -64,9 +64,13 @@ import org.apache.http.impl.client.HttpClients;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebJavaJUnitTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebJavaTestNGTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebPythonTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebRubyTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebNodeTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumJavaJUnitTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumJavaTestNGTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumPythonTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumRubyTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumNodeTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.CalabashTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.InstrumentationTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.UIAutomationTest;
@@ -521,6 +525,31 @@ public class AWSDeviceFarm {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_PYTHON);
     }
 
+    /**
+     * Upload a test to Device Farm.
+     *
+     * @param project The Device Farm project to upload to.
+     * @param test    Test object containing relevant test information.
+     * @return The Device Farm Upload object.
+     * @throws IOException
+     * @throws AWSDeviceFarmException
+     */
+    public Upload uploadTest(Project project, AppiumRubyTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
+        return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_RUBY);
+    }
+
+    /**
+     * Upload a test to Device Farm.
+     *
+     * @param project The Device Farm project to upload to.
+     * @param test    Test object containing relevant test information.
+     * @return The Device Farm Upload object.
+     * @throws IOException
+     * @throws AWSDeviceFarmException
+     */
+    public Upload uploadTest(Project project, AppiumNodeTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
+        return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_NODE);
+    }
 
     /**
      * Upload a test to Device Farm.
@@ -558,6 +587,32 @@ public class AWSDeviceFarm {
      */
     public Upload uploadTest(Project project, AppiumWebPythonTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_WEB_PYTHON);
+    }
+
+    /**
+     * Upload a test to Device Farm.
+     *
+     * @param project The Device Farm project to upload to.
+     * @param test    Test object containing relevant test information.
+     * @return The Device Farm Upload object.
+     * @throws IOException
+     * @throws AWSDeviceFarmException
+     */
+    public Upload uploadTest(Project project, AppiumWebRubyTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
+        return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_WEB_RUBY);
+    }
+
+    /**
+     * Upload a test to Device Farm.
+     *
+     * @param project The Device Farm project to upload to.
+     * @param test    Test object containing relevant test information.
+     * @return The Device Farm Upload object.
+     * @throws IOException
+     * @throws AWSDeviceFarmException
+     */
+    public Upload uploadTest(Project project, AppiumWebNodeTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
+        return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_WEB_NODE);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -302,6 +302,7 @@ public class AWSDeviceFarm {
         uploads.addAll(result.getUploads());
         while (result.getNextToken() != null) {
             ListUploadsRequest request = new ListUploadsRequest();
+            request.setArn(project.getArn());
             request.setNextToken(result.getNextToken());
             result = api.listUploads(request);
             uploads.addAll(result.getUploads());

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -925,7 +925,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 CalabashTest test = new CalabashTest.Builder()
                         .withFeatures(env.expand(calabashFeatures))
                         .withTags(env.expand(calabashTags))
-                        .withProfile(calabashProfile)
+                        .withProfile(env.expand(calabashProfile))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -947,7 +947,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case INSTRUMENTATION: {
                 InstrumentationTest test = new InstrumentationTest.Builder()
                         .withArtifact(env.expand(junitArtifact))
-                        .withFilter(junitFilter)
+                        .withFilter(env.expand(junitFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -963,7 +963,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case UIAUTOMATOR: {
                 UIAutomatorTest test = new UIAutomatorTest.Builder()
                         .withTests(env.expand(uiautomatorArtifact))
-                        .withFilter(uiautomatorFilter)
+                        .withFilter(env.expand(uiautomatorFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -993,7 +993,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case XCTEST: {
                 XCTestTest test = new XCTestTest.Builder()
                         .withTests(xctestArtifact)
-                        .withFilter(xctestFilter)
+                        .withFilter(env.expand(xctestFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -1006,9 +1006,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             }
 
             case XCTEST_UI: {
+
                 XCTestUITest test = new XCTestUITest.Builder()
                         .withTests(xctestUiArtifact)
-                        .withFilter(xctestUiFilter)
+                        .withFilter(env.expand(xctestUiFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -411,7 +411,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @return The String should bu input as the parameter of the devicefarm API.
      */
     public String transformTestToRunForWebApp(@Nonnull String testToRun) {
-        if (ifWebApp) {
+        if (testToRun != null && ifWebApp) {
             if (testToRun.equalsIgnoreCase("APPIUM_PYTHON")) return"APPIUM_WEB_PYTHON";
             else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_JUNIT")) return"APPIUM_WEB_JAVA_JUNIT";
             else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_TESTNG")) return"APPIUM_WEB_JAVA_TESTNG";

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -65,9 +65,13 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumJavaJUnitTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumJavaTestNGTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumPythonTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumRubyTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumNodeTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebJavaJUnitTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebJavaTestNGTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebPythonTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebRubyTest;
+import org.jenkinsci.plugins.awsdevicefarm.test.AppiumWebNodeTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.CalabashTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.InstrumentationTest;
 import org.jenkinsci.plugins.awsdevicefarm.test.UIAutomationTest;
@@ -132,6 +136,12 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
 
     // Appium Python
     public String appiumPythonTest;
+
+    // Appium Ruby
+    public String appiumRubyTest;
+
+    // Appium Node
+    public String appiumNodeTest;
 
     // Calabash
     public String calabashFeatures;
@@ -227,6 +237,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @param appiumJavaJUnitTest           The path to the Appium Java Junit tests.
      * @param appiumJavaTestNGTest          The path to the Appium Java tests.
      * @param appiumPythonTest              The path to the Appium python tests.
+     * @param appiumRubyTest                The path to the Appium Ruby tests.
+     * @param appiumNodeTest                The path to the Appium Node tests.
      * @param calabashFeatures              The path to the Calabash tests to be run.
      * @param calabashTags                  Calabash tags to attach to the test.
      * @param calabashProfile               Calabash Profile to attach to the test.
@@ -241,7 +253,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @param xctestUiFilter                The filter to apply to the XCTest UI tests.
      * @param appiumVersionJunit            The version of the Appium used for Appium Junit tests.
      * @param appiumVersionPython           The version of the Appium used for Appium Python tests.
-     * @param appiumVersionTestng           The version of the Appium used for Appoum Testing tests.
+     * @param appiumVersionTestng           The version of the Appium used for Appium Testing tests.
      * @param ifWebApp                      Whether it is a web app.
      * @param extraData                     Whether it has extra data.
      * @param extraDataArtifact             The path to the extra data.
@@ -279,6 +291,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                                  String appiumJavaJUnitTest,
                                  String appiumJavaTestNGTest,
                                  String appiumPythonTest,
+                                 String appiumRubyTest,
+                                 String appiumNodeTest,
                                  String calabashFeatures,
                                  String calabashTags,
                                  String calabashProfile,
@@ -328,6 +342,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         this.appiumJavaJUnitTest = appiumJavaJUnitTest;
         this.appiumJavaTestNGTest = appiumJavaTestNGTest;
         this.appiumPythonTest = appiumPythonTest;
+        this.appiumRubyTest = appiumRubyTest;
+        this.appiumNodeTest = appiumNodeTest;
         this.calabashFeatures = calabashFeatures;
         this.calabashTags = calabashTags;
         this.calabashProfile = calabashProfile;
@@ -399,6 +415,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             if (testToRun.equalsIgnoreCase("APPIUM_PYTHON")) return"APPIUM_WEB_PYTHON";
             else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_JUNIT")) return"APPIUM_WEB_JAVA_JUNIT";
             else if (testToRun.equalsIgnoreCase("APPIUM_JAVA_TESTNG")) return"APPIUM_WEB_JAVA_TESTNG";
+            else if (testToRun.equalsIgnoreCase("APPIUM_RUBY")) return"APPIUM_WEB_RUBY";
+            else if (testToRun.equalsIgnoreCase("APPIUM_NODE")) return"APPIUM_WEB_NODE";
         }
         return testToRun;
     }
@@ -883,6 +901,34 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 break;
             }
 
+            case APPIUM_RUBY: {
+                AppiumRubyTest test = new AppiumRubyTest.Builder()
+                        .withTests(env.expand(appiumRubyTest))
+                        .build();
+
+                Upload upload = adf.uploadTest(project, test);
+
+                testToSchedule = new ScheduleRunTest()
+                        .withType(testType)
+                        .withTestPackageArn(upload.getArn());
+
+                break;
+            }
+
+            case APPIUM_NODE: {
+                AppiumNodeTest test = new AppiumNodeTest.Builder()
+                        .withTests(env.expand(appiumNodeTest))
+                        .build();
+
+                Upload upload = adf.uploadTest(project, test);
+
+                testToSchedule = new ScheduleRunTest()
+                        .withType(testType)
+                        .withTestPackageArn(upload.getArn());
+
+                break;
+            }
+
             case APPIUM_WEB_JAVA_JUNIT: {
                 AppiumWebJavaJUnitTest test = new AppiumWebJavaJUnitTest.Builder()
                         .withTests(env.expand(appiumJavaJUnitTest))
@@ -925,6 +971,34 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                         .withTestPackageArn(upload.getArn());
 
                 testToSchedule.addParametersEntry("appium_version", appiumVersionPython);
+                break;
+            }
+
+            case APPIUM_WEB_RUBY: {
+                AppiumWebRubyTest test = new AppiumWebRubyTest.Builder()
+                        .withTests(env.expand(appiumRubyTest))
+                        .build();
+
+                Upload upload = adf.uploadTest(project, test);
+
+                testToSchedule = new ScheduleRunTest()
+                        .withType(testType)
+                        .withTestPackageArn(upload.getArn());
+
+                break;
+            }
+
+            case APPIUM_WEB_NODE: {
+                AppiumWebNodeTest test = new AppiumWebNodeTest.Builder()
+                        .withTests(env.expand(appiumNodeTest))
+                        .build();
+
+                Upload upload = adf.uploadTest(project, test);
+
+                testToSchedule = new ScheduleRunTest()
+                        .withType(testType)
+                        .withTestPackageArn(upload.getArn());
+
                 break;
             }
 
@@ -1146,6 +1220,24 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 break;
             }
 
+            case APPIUM_RUBY: {
+                if (appiumRubyTest == null || appiumRubyTest.isEmpty()) {
+                    writeToLog(log, "Appium Ruby test must be set.");
+                    return false;
+                }
+
+                break;
+            }
+
+            case APPIUM_NODE: {
+                if (appiumNodeTest == null || appiumNodeTest.isEmpty()) {
+                    writeToLog(log, "Appium Node test must be set.");
+                    return false;
+                }
+
+                break;
+            }
+
             case APPIUM_WEB_JAVA_JUNIT: {
                 if (appiumJavaJUnitTest == null || appiumJavaJUnitTest.isEmpty()) {
                     writeToLog(log, "Appium Java Junit test for the web application must be set.");
@@ -1167,6 +1259,24 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case APPIUM_WEB_PYTHON: {
                 if (appiumPythonTest == null || appiumPythonTest.isEmpty()) {
                     writeToLog(log, "Appium Python test for the web application must be set.");
+                    return false;
+                }
+
+                break;
+            }
+
+            case APPIUM_WEB_RUBY: {
+                if (appiumRubyTest == null || appiumRubyTest.isEmpty()) {
+                    writeToLog(log, "Appium Ruby test for the web application must be set.");
+                    return false;
+                }
+
+                break;
+            }
+
+            case APPIUM_WEB_NODE: {
+                if (appiumNodeTest == null || appiumNodeTest.isEmpty()) {
+                    writeToLog(log, "Appium Node test for the web application must be set.");
                     return false;
                 }
 
@@ -1535,6 +1645,33 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             return FormValidation.ok();
         }
 
+        /**
+         * Validate the user entered artifact for Appium Ruby test content.
+         *
+         * @param appiumRubyTest The path to the test file.
+         * @return Whether or not the form was ok.
+         */
+        @SuppressWarnings("unused")
+        public FormValidation doCheckAppiumRubyTest(@QueryParameter String appiumRubyTest) {
+            if (appiumRubyTest == null || appiumRubyTest.isEmpty()) {
+                return FormValidation.error("Required!");
+            }
+            return FormValidation.ok();
+        }
+
+        /**
+         * Validate the user entered artifact for Appium Node test content.
+         *
+         * @param appiumNodeTest The path to the test file.
+         * @return Whether or not the form was ok.
+         */
+        @SuppressWarnings("unused")
+        public FormValidation doCheckAppiumNodeTest(@QueryParameter String appiumNodeTest) {
+            if (appiumNodeTest == null || appiumNodeTest.isEmpty()) {
+                return FormValidation.error("Required!");
+            }
+            return FormValidation.ok();
+        }
 
         /**
          * Validate the user entered file path to local Calabash features.
@@ -1888,6 +2025,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @return The List of device pool names associated with that project.
          */
         private synchronized List<String> getAWSDeviceFarmTestSpec(String projectName) {
+            testSpecCache.clear();
             List<String> testSpecNames = testSpecCache.get(projectName);
 
             if (testSpecNames == null || testSpecNames.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmUploadType.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmUploadType.java
@@ -26,6 +26,8 @@ public enum AWSDeviceFarmUploadType {
     APPIUM_JAVA_TESTNG("APPIUM_JAVA_TESTNG_TEST_PACKAGE"),          // Test
     APPIUM_JAVA_JUNIT("APPIUM_JAVA_JUNIT_TEST_PACKAGE"),            // Test
     APPIUM_PYTHON("APPIUM_PYTHON_TEST_PACKAGE"),                    // Test
+    APPIUM_RUBY("APPIUM_RUBY_TEST_PACKAGE"),                        // Test
+    APPIUM_NODE("APPIUM_NODE_TEST_PACKAGE"),                        // Test
     CALABASH ("CALABASH_TEST_PACKAGE"),                             // Test
     INSTRUMENTATION ("INSTRUMENTATION_TEST_PACKAGE"),               // Test
     UIAUTOMATOR ("UIAUTOMATOR_TEST_PACKAGE"),                       // Test
@@ -35,6 +37,8 @@ public enum AWSDeviceFarmUploadType {
     APPIUM_WEB_PYTHON("APPIUM_WEB_PYTHON_TEST_PACKAGE"),            // Test
     APPIUM_WEB_JAVA_TESTNG("APPIUM_WEB_JAVA_TESTNG_TEST_PACKAGE"),  // Test
     APPIUM_WEB_JAVA_JUNIT("APPIUM_WEB_JAVA_JUNIT_TEST_PACKAGE"),    // Test
+    APPIUM_WEB_NODE("APPIUM_WEB_NODE_TEST_PACKAGE"),                // Test
+    APPIUM_WEB_RUBY("APPIUM_WEB_RUBY_TEST_PACKAGE"),                // Test
     EXTERNAL_DATA("EXTERNAL_DATA");                                 // Extra Data
 
     private final String type;

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumNodeTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumNodeTest.java
@@ -1,0 +1,67 @@
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+package org.jenkinsci.plugins.awsdevicefarm.test;
+
+/**
+ * POJO class for an Appium Node test.
+ */
+public class AppiumNodeTest {
+    private final String tests;
+
+    /**
+     * Static builder class.
+     */
+    public static class Builder {
+        private String tests;
+
+        /**
+         * Test setter.
+         *
+         * @param tests Path to the tests to run.
+         * @return The builder object.
+         */
+        public Builder withTests(String tests) {
+            this.tests = tests;
+            return this;
+        }
+
+        /**
+         * Build method.
+         *
+         * @return The new POJO.
+         */
+        public AppiumNodeTest build() {
+            return new AppiumNodeTest(this);
+        }
+    }
+
+    /**
+     * POJO constructor with builder.
+     *
+     * @param builder The builder to use.
+     */
+    private AppiumNodeTest(Builder builder) {
+        this.tests = builder.tests;
+    }
+
+    /**
+     * Test getter.
+     *
+     * @return The path to the tests to run.
+     */
+    public String getTests() {
+        return this.tests;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumRubyTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumRubyTest.java
@@ -1,0 +1,67 @@
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+package org.jenkinsci.plugins.awsdevicefarm.test;
+
+/**
+ * POJO class for an Appium Ruby test.
+ */
+public class AppiumRubyTest {
+    private final String tests;
+
+    /**
+     * Static builder class.
+     */
+    public static class Builder {
+        private String tests;
+
+        /**
+         * Test setter.
+         *
+         * @param tests Path to the tests to run.
+         * @return The builder object.
+         */
+        public Builder withTests(String tests) {
+            this.tests = tests;
+            return this;
+        }
+
+        /**
+         * Build method.
+         *
+         * @return The new POJO.
+         */
+        public AppiumRubyTest build() {
+            return new AppiumRubyTest(this);
+        }
+    }
+
+    /**
+     * POJO constructor with builder.
+     *
+     * @param builder The builder to use.
+     */
+    private AppiumRubyTest(Builder builder) {
+        this.tests = builder.tests;
+    }
+
+    /**
+     * Test getter.
+     *
+     * @return The path to the tests to run.
+     */
+    public String getTests() {
+        return this.tests;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumWebNodeTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumWebNodeTest.java
@@ -1,0 +1,67 @@
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+package org.jenkinsci.plugins.awsdevicefarm.test;
+
+/**
+ * POJO class for a Web Appium Node test.
+ */
+public class AppiumWebNodeTest {
+    private final String tests;
+
+    /**
+     * Static builder class.
+     */
+    public static class Builder {
+        private String tests;
+
+        /**
+         * Test setter.
+         *
+         * @param tests Path to the tests to run.
+         * @return The builder object.
+         */
+        public Builder withTests(String tests) {
+            this.tests = tests;
+            return this;
+        }
+
+        /**
+         * Build method.
+         *
+         * @return The new POJO.
+         */
+        public AppiumWebNodeTest build() {
+            return new AppiumWebNodeTest(this);
+        }
+    }
+
+    /**
+     * POJO constructor with builder.
+     *
+     * @param builder The builder to use.
+     */
+    private AppiumWebNodeTest(Builder builder) {
+        this.tests = builder.tests;
+    }
+
+    /**
+     * Test getter.
+     *
+     * @return The path to the tests to run.
+     */
+    public String getTests() {
+        return this.tests;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumWebRubyTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/AppiumWebRubyTest.java
@@ -1,0 +1,67 @@
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+// http://aws.amazon.com/apache2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+package org.jenkinsci.plugins.awsdevicefarm.test;
+
+/**
+ * POJO class for a Web Appium Ruby test.
+ */
+public class AppiumWebRubyTest {
+    private final String tests;
+
+    /**
+     * Static builder class.
+     */
+    public static class Builder {
+        private String tests;
+
+        /**
+         * Test setter.
+         *
+         * @param tests Path to the tests to run.
+         * @return The builder object.
+         */
+        public Builder withTests(String tests) {
+            this.tests = tests;
+            return this;
+        }
+
+        /**
+         * Build method.
+         *
+         * @return The new POJO.
+         */
+        public AppiumWebRubyTest build() {
+            return new AppiumWebRubyTest(this);
+        }
+    }
+
+    /**
+     * POJO constructor with builder.
+     *
+     * @param builder The builder to use.
+     */
+    private AppiumWebRubyTest(Builder builder) {
+        this.tests = builder.tests;
+    }
+
+    /**
+     * Test getter.
+     *
+     * @return The path to the tests to run.
+     */
+    public String getTests() {
+        return this.tests;
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -105,6 +105,22 @@
       </f:nested>
     </f:radioBlock>
 
+    <f:radioBlock name="testToRun" value="APPIUM_RUBY" checked="${instance.isTestType('APPIUM_RUBY')}" title="Appium Ruby (Available in custom environment only)" inline="true">
+      <f:nested>
+        <f:entry title="Tests" field="appiumRubyTest" description="[Required] Pattern to find Ruby tests.">
+          <f:textbox />
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+
+    <f:radioBlock name="testToRun" value="APPIUM_NODE" checked="${instance.isTestType('APPIUM_NODE')}" title="Appium Node (Available in custom environment only)" inline="true">
+      <f:nested>
+        <f:entry title="Tests" field="appiumNodeTest" description="[Required] Pattern to find Node tests.">
+          <f:textbox />
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+
     <f:radioBlock name="testToRun" value="CALABASH" checked="${instance.isTestType('CALABASH')}" title="Calabash" inline="true">
       <f:nested>
         <f:entry title="Features" field="calabashFeatures" description="[Required] Pattern to find features.zip.">
@@ -173,9 +189,8 @@
   </f:section>
 
  <f:section title="Choose your execution environment">
-    <f:radioBlock name="environmentToRun" value="StandardEnvironment" checked="${instance.isStandardEnvironment('StandardEnvironment')}" title="Standard environment" inline="true">
-      </f:radioBlock>
-
+      <f:radioBlock name="environmentToRun" value="StandardEnvironment" checked="${instance.isStandardEnvironment('StandardEnvironment')}" title="Standard environment" inline="true">
+        </f:radioBlock>
     <f:radioBlock name="environmentToRun" value="CustomEnvironment" checked="${instance.isCustomEnvironment('CustomEnvironment')}" title="Custom Environment" inline="true">
       <f:nested>
         <f:entry title="Select Test Specification file" field="testSpecName" description="Choose the testSpec file.">

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -38,7 +38,7 @@ public class AWSDeviceFarmRecorderTest {
                 "TestProjectName", "TestDevicePool", null, null,
                 null, null, "APPIUM_JAVA_JUNIT", false, false, null,
                 null, null, null, null, null, null,
-                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 null, null, null, null, null, null,


### PR DESCRIPTION
1. Add support for Appium Ruby and Appium Node
2. Add function to filter out default specs from drop down for Ruby and Node
3. Check for environment variables on filters
4. Fix for project ARN not present for request returning possible paginated response