### PR TITLE
Update AWSDeviceFarmTestResultAction.java

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -36,7 +36,7 @@ import java.io.PrintStream;
 public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSDeviceFarmTestResultAction> implements StaplerProxy {
 
     private static final int DefaultUpdateInterval = 30 * 1000;
-    private PrintStream log;
+    private transient PrintStream log;
     private AWSDeviceFarmTestResult result;
 
     public AWSDeviceFarmTestResultAction(AbstractBuild<?, ?> owner, AWSDeviceFarmTestResult result) {


### PR DESCRIPTION
A fix for 
```
java.lang.UnsupportedOperationException: Refusing to marshal java.io.PrintStream for security reasons
```
Find more details about the issue [here](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jenkinsci-users/pM0_b7Sz8Ts/tZuNDuBjBQAJ). 
