### PR TITLE
Add support for Device Locale

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -266,6 +266,12 @@
         <f:textbox default="-122.3941"/>
       </f:entry>
     </f:optionalBlock>
+
+    <f:optionalBlock name="deviceLocaleFlag" title="Specify Device Locale" checked="${instance.deviceLocaleFlag}" inline="true">
+      <f:entry title="Device Locale" field="deviceLocale" description="[Optional] Add the device locale." >
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 
   <f:section title="Execution Information">

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -43,7 +43,7 @@ public class AWSDeviceFarmRecorderTest {
                 null, null, null, null, false, false,
                 null, null, null, null, null, null,
                 false, false, false, 10, false, false,
-                false, false, false, null, null, null
+                false, false, false, null, null, null, false, null
         );
         p.getPublishersList().add(rec);
 


### PR DESCRIPTION
This feature adds support for setting a device locale on the device under test. This is already available in the APIs of Device Farm.

### Testing done

The testing was done on Android and iOS devices by changing the language to "es_ES" and validating the results on the device. Attached is screenshot of the feature working.
<img width="1109" height="327" alt="Screenshot 2025-07-31 at 7 33 46 PM" src="https://github.com/user-attachments/assets/a6328ad9-04d0-4106-bbe4-10f7676d1a6e" />


### Submitter checklist
- [ X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ X] Link to relevant issues in GitHub or Jira
- [ N/A] Link to relevant pull requests, esp. upstream and downstream changes
- [ X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
